### PR TITLE
Updated the spark-submit example so that the correct args are passed to SparkBWA.jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ and uploaded to HDFS:
 	
 Finally, we can execute **SparkBWA** on the cluster. Again, we assume that Spark is stored at *spark_dir*:
 
-	spark_dir/bin/spark-submit --class SparkBWA --master yarn-client SparkBWA.jar --driver-memory 1500m --executor-memory 1500m --executor-cores 1 --archives bwa.zip --verbose --num-executors 32 -algorithm mem -reads paired -index /Data/HumanBase/hg38 -partitions 32 ERR000589_1.filt.fastq ERR000589_2.filt.fastq Output_ERR000589
+	spark_dir/bin/spark-submit --class SparkBWA --master yarn-client --driver-memory 1500m --executor-memory 1500m --executor-cores 1 --archives bwa.zip --verbose --num-executors 32 SparkBWA.jar -algorithm mem -reads paired -index /Data/HumanBase/hg38 -partitions 32 ERR000589_1.filt.fastq ERR000589_2.filt.fastq Output_ERR000589
 
 Options:
 * **-algorithm mem** - Sequence alignment algorithm (mem - *BWA-MEM*, aln - *BWA-backtrack*).


### PR DESCRIPTION
Currently every argument after "--master yarn-client SparkBWA.jar" is being passed to SparkBWA. This means that some of the spark-submit related arguments (such as --driver-memory 1500m) is being passed to SparkBWA instead of spark-submit, and thus causing the command to not work.

 This commit just updates this so that the arguments are being passed correctly.
