### PR TITLE
fix empty sam files

### DIFF
--- a/src/main/java/com/github/sparkbwa/BwaOptions.java
+++ b/src/main/java/com/github/sparkbwa/BwaOptions.java
@@ -308,6 +308,7 @@ public class BwaOptions {
 				inputPath2 = otherArguments[1];
 				outputPath = otherArguments[2];
 			}
+			outputHdfsDir=outputPath;
 
 		} catch (UnrecognizedOptionException e) {
 			e.printStackTrace();


### PR DESCRIPTION
fix empty sam files:
citiususc#22

Reason:
outputPath in map and outputHdfsDir in reduce
outputHdfsDir is null

so:
outputHdfsDir=outputPath